### PR TITLE
Enhance sbtrace Commands with Warning Message

### DIFF
--- a/libslub/frontend/commands/gdb/sbtrace.py
+++ b/libslub/frontend/commands/gdb/sbtrace.py
@@ -56,6 +56,10 @@ Setup break points for the specified slab names""",
         """
 
         log.debug("sbtrace.invoke()")
+        
+        if len(self.args.names) == 0:
+            print("No slab cache names specified")
+            return
 
         for name in self.args.names:
             slab_cache = sb.sb.find_slab_cache(name)


### PR DESCRIPTION
During my initial testing of the sbtrace commands, I encountered a misunderstanding of the command behavior. It appears that providing at least one slab name is essential for proper execution.

Changes:

   - Added a simple warning message to the sbtrace commands, it prompts users when no slab cache names are specified