### PR TITLE
Fix compability issue in python 3.12+

### DIFF
--- a/libslub/pyslub.py
+++ b/libslub/pyslub.py
@@ -30,7 +30,7 @@ class pyslab:
         debugger = pgp.pygdbpython()
         self.dbg = d.pydbg(debugger)
 
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         path = os.path.abspath(os.path.dirname(__file__))
         config_path = os.path.join(path, "libslub.cfg")
         config.read(config_path)


### PR DESCRIPTION
SafeConfigParser was renamed to ConfigParser.
Closes #10 

Works fine on both python 3.8.10 and 3.12 with this patch.